### PR TITLE
[b] Fix load constant issue when using this gem with rails

### DIFF
--- a/lib/messenger_platform/entities/message.rb
+++ b/lib/messenger_platform/entities/message.rb
@@ -1,3 +1,4 @@
+require 'typhoeus'
 module MessengerPlatform
   module Entities
     class Message

--- a/lib/messenger_platform/entities/message.rb
+++ b/lib/messenger_platform/entities/message.rb
@@ -1,4 +1,5 @@
 require 'typhoeus'
+
 module MessengerPlatform
   module Entities
     class Message


### PR DESCRIPTION
When using this gem with rails, I encountered an error with loading constant
`NameError: uninitialized constant MessengerPlatform::Entities::Message::Typhoeus`

Explicit require typhoeus resolves this issue.
